### PR TITLE
Changed TwitchChatSender to interior mutability (The branch name is a lie)

### DIFF
--- a/chatbot/src/connect/mod.rs
+++ b/chatbot/src/connect/mod.rs
@@ -9,8 +9,8 @@ pub enum ConnectorError {
     MessageReceiveFailed(String),
     #[error("Sending message failed: {0:?}")]
     MessageSendFailed(String),
-    #[error("Unknown command: {0:?}")]
-    UnknownCommand(String),
+    // #[error("Unknown command: {0:?}")]
+    // UnknownCommand(String),
 }
 
 #[derive(Debug)]
@@ -40,12 +40,12 @@ impl Command {
             match command_text {
                 "help" => Some(Self {
                     commmand_type: CommandType::Help,
-                    options: options,
+                    options,
                     user_name: user_name.to_owned(),
                 }),
                 "info" => Some(Self {
                     commmand_type: CommandType::Info,
-                    options: options,
+                    options,
                     user_name: user_name.to_owned(),
                 }),
                 _ => None,
@@ -67,6 +67,14 @@ impl TextMessage {
             text: text.to_owned(),
             user_name: user_name.to_owned(),
         }
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+    
+    pub fn user_name(&self) -> &str {
+        &self.user_name
     }
 }
 
@@ -155,12 +163,12 @@ impl EventContent {
                 MessageBody => {
                     if codepoint == '!' {
                         return Some(EventContent::Command(Command::new(
-                            &message[i..].trim(),
+                            message[i..].trim(),
                             user_name,
                         )?));
                     } else {
                         return Some(EventContent::TextMessage(TextMessage::new(
-                            &message[i..].trim(),
+                            message[i..].trim(),
                             user_name,
                         )));
                     }
@@ -173,7 +181,7 @@ impl EventContent {
 
 pub trait Event {
     fn content(&self) -> &EventContent;
-    fn respond(&mut self, response: &str) -> Result<(), ConnectorError>;
+    fn respond(&self, response: &str) -> Result<(), ConnectorError>;
 }
 
 pub trait Connector {

--- a/chatbot/src/connect/twitch_chat/event.rs
+++ b/chatbot/src/connect/twitch_chat/event.rs
@@ -1,4 +1,4 @@
-use crate::connect::EventContent;
+use crate::EventContent;
 
 #[derive(Debug)]
 pub enum InternalEventContent {
@@ -33,12 +33,8 @@ mod tests {
         let ping_message = "PING :tmi.twitch.tv";
         let parsed = TwitchChatInternalEvent::new(ping_message);
         assert!(parsed.is_some());
-        if let TwitchChatInternalEvent::Internal(internal_event) = parsed.unwrap() {
-            if let InternalEventContent::Ping(server) = internal_event {
-                assert_eq!(server, "tmi.twitch.tv");
-            } else {
-                unreachable!();
-            }
+        if let TwitchChatInternalEvent::Internal(InternalEventContent::Ping(server)) =  parsed.unwrap() {
+            assert_eq!(server, "tmi.twitch.tv");
         } else {
             unreachable!();
         }

--- a/chatbot/src/connect/twitch_chat/request.rs
+++ b/chatbot/src/connect/twitch_chat/request.rs
@@ -3,11 +3,11 @@ use crate::connect::{ConnectorError, Event, EventContent};
 
 pub struct TwitchChatEvent<'a> {
     content: EventContent,
-    sender: &'a mut TwitchChatSender,
+    sender: &'a TwitchChatSender,
 }
 
 impl<'a> TwitchChatEvent<'a> {
-    pub fn new(content: EventContent, sender: &'a mut TwitchChatSender) -> Self {
+    pub fn new(content: EventContent, sender: &'a TwitchChatSender) -> Self {
         Self {
             content,
             sender,

--- a/chatbot/src/connect/twitch_chat/request.rs
+++ b/chatbot/src/connect/twitch_chat/request.rs
@@ -9,8 +9,8 @@ pub struct TwitchChatEvent<'a> {
 impl<'a> TwitchChatEvent<'a> {
     pub fn new(content: EventContent, sender: &'a mut TwitchChatSender) -> Self {
         Self {
-            content: content,
-            sender: sender,
+            content,
+            sender,
         }
     }
 }
@@ -20,7 +20,7 @@ impl<'a> Event for TwitchChatEvent<'a> {
         &self.content
     }
 
-    fn respond(&mut self, response: &str) -> Result<(), ConnectorError> {
+    fn respond(&self, response: &str) -> Result<(), ConnectorError> {
         self.sender.send_message(response)
     }
 }

--- a/chatbot/src/connect/twitch_chat/sending.rs
+++ b/chatbot/src/connect/twitch_chat/sending.rs
@@ -1,32 +1,32 @@
 use crate::connect::ConnectorError;
-use std::{env, net::TcpStream};
+use std::{cell::RefCell, env, net::TcpStream};
 use websocket::{sync::Writer, Message};
 
 pub struct TwitchChatSender {
-    sender: Writer<TcpStream>,
+    sender: RefCell<Writer<TcpStream>>,
     channel: String,
 }
 
 impl TwitchChatSender {
     pub fn new(sender: Writer<TcpStream>, channel: String) -> Self {
         Self {
-            sender: sender,
-            channel: channel,
+            sender : RefCell::new(sender),
+            channel,
         }
     }
 
-    pub fn send_message(&mut self, msg: &str) -> Result<(), ConnectorError> {
+    pub fn send_message(&self, msg: &str) -> Result<(), ConnectorError> {
         self.send_raw_message(format!("PRIVMSG #{} :{}", self.channel, msg))
     }
 
-    pub fn send_raw_message(&mut self, message: String) -> Result<(), ConnectorError> {
+    pub fn send_raw_message(&self, message: String) -> Result<(), ConnectorError> {
         let message_obj = Message::text(message);
-        self.sender.send_message(&message_obj).map_err(|err| {
+        self.sender.borrow_mut().send_message(&message_obj).map_err(|err| {
             ConnectorError::MessageSendFailed(format!("Could not send message: {:?}", err))
         })
     }
 
-    pub fn login(&mut self, access_token: &str) -> Result<(), ConnectorError> {
+    pub fn login(&self, access_token: &str) -> Result<(), ConnectorError> {
         let user_name = env::var("TWITCH_CHAT_USER").map_err(|err| {
             ConnectorError::MessageReceiveFailed(format!(
                 "Could not get user name from environment variable: {:?}",

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let info_command_handler = StaticStringCommandHandler::new(info_command_message);
     loop {
         let message = connector.recv_event();
-        if let Ok(mut msg) = message {
+        if let Ok(msg) = message {
             match msg.content() {
                 EventContent::Command(info) => {
                     match info.commmand_type {
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 EventContent::Join(_) => (),
                 EventContent::Part(_) => (),
-                EventContent::TextMessage(_) => (),
+                EventContent::TextMessage(tm) => println!("{}: {}", &tm.user_name(), &tm.text()),
             };
         };
     }


### PR DESCRIPTION
Changed `TwitchChatSender.sender` to a `RefCell<Writer<TcpStream>>`
This allows for non mutable references all over the place, (methods of TwitchChatSender, TwitchChatEvent, Event).
Which in turn removes the mutability warnings in main.rs

The downside is the loss of some borrow guarantees. But all the writing is done at the same place, there is a single owner, I don't see how this could be a problem.

Also fixed a couple more warnings, for some reason i have more of these than you do.

A couple pedantic remarks:
- There is too much useless abstraction right now. That whole event trait is completely useless. There is only one implementation of it (TwitchChatEvent). In the unlikely event there could be a new connector type, the abstraction would take place on the sender field of that struct.
- It's pretty hard right now to find what is where. Though that's obviously due to some of the restructuring that took place. It might be time to consolidate and put the common stuff together.
- I personally never put anything in mod.rs files (that's a matter of taste and opinion).
- I think we're headed to a code structure that's a bit on the OOP side, while rust is not. This leads to a stratified structure, and renders the whole thing harder to modify as we discover new requirements.
- Not every function needs to be part of an impl.


