### PR TITLE
Added .env support because my bot doesn't work in your channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Cargo.lock
 **/*.rs.bk
 
 certificates/
+.env

--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -12,3 +12,4 @@ tokio = { version = "1.12.0", features = ["full"] }
 serde_json = "1.0.68"
 tiny_http = { version = "0.9.0", features = ["ssl"] }
 thiserror = "1.0"
+dotenv = "0.15"

--- a/chatbot/src/chat_bot.rs
+++ b/chatbot/src/chat_bot.rs
@@ -1,71 +1,142 @@
 use std::collections::HashSet;
 
-use crate::connect::{CommandType, ConnectorError, EventContent, TwitchChatConnector};
+use crate::connect::{Command, CommandType, EventContent};
 
+#[derive(Debug)]
 pub struct ChatBot {
-    chatters: HashSet<String>,
-    help_message: String,
-    info_message: String,
-    connector: TwitchChatConnector,
+    chatters: HashSet<String>, // NOTE: probably replace String with a User struct when we need it.
 }
+
+// This will later probably have commands to do http requests to retreive
+// user information and who knows what else
+#[derive(Debug)]
+pub enum ChatBotCommand {
+    SendMessage(String),
+    LogTextMessage(String),
+}
+
+const HELP_MESSAGE: &str =
+    "!help: Show this help | !info: Show some information about the chat bot";
+const INFO_MESSAGE : &str =
+    "Hello, my name is TwitchBotanist. I am a twitch chat bot written in Rust. If you want to know what you can ask me, write '!help' into the chat!";
 
 impl ChatBot {
     pub fn new() -> Self {
-        Self {chatters: HashSet::<String>::new(), help_message: "!help: Show this help | !info: Show some information about the chat bot".to_owned(), info_message: "Hello, my name is TwitchBotanist. I am a twitch chat bot written in Rust. If you want to know what you can ask me, write '!help' into the chat!".to_owned(), connector: TwitchChatConnector::new("captaincallback")}
+        Self {
+            chatters: HashSet::<String>::new(),
+        }
     }
 
-    fn handle_event(&mut self, event: EventContent) {
-        match event {
-            EventContent::Command(info) => {
-                match info.commmand_type {
-                    CommandType::Help => {
-                        self.connector.send_message(&self.help_message).unwrap();
-                    }
-                    CommandType::Info => {
-                        self.connector.send_message(&self.info_message).unwrap();
-                    }
-                    CommandType::Slap => {
-                        println!("{:?}", self.chatters);
-                        let chatters = &self.chatters;
-                        let slapping_user = info.user_name;
-                        let slapped_user = info
-                            .options
-                            .get(0)
-                            .and_then(|slapped_user| chatters.get(slapped_user));
-                        if let Some(slapped_user) = slapped_user {
-                            self.connector
-                                .send_message(
-                                    format!(
-                                        "{} slaps {} around a bit with a large trout",
-                                        slapping_user, slapped_user
-                                    )
-                                    .as_str(),
-                                )
-                                .ok();
-                        }
-                    }
-                };
+    fn handle_command(&mut self, command: Command) -> Option<ChatBotCommand> {
+        println!("Executing this command: {:#?}", command);
+        use ChatBotCommand::*;
+        match command.commmand_type {
+            CommandType::Help => Some(SendMessage(HELP_MESSAGE.to_string())),
+            CommandType::Info => Some(SendMessage(INFO_MESSAGE.to_string())),
+            CommandType::Slap => {
+                println!("Slapping one of these guys \n{:#?}", self.chatters);
+                // Notice how we can now do everything in a single expression
+                // because we removed the IO from this place
+                let slapping_user = command.user_name;
+                println!("This guy specifically : {}", &slapping_user);
+                command
+                    .options
+                    .get(0)
+                    .and_then(|slapped_user| self.chatters.get(slapped_user))
+                    .map(|slapped_user| {
+                        SendMessage(format!(
+                            "{} slaps {} around a bit with a large trout",
+                            slapping_user, slapped_user
+                        ))
+                    })
             }
+        }
+    }
+
+    pub fn handle_event(&mut self, event: EventContent) -> Option<ChatBotCommand> {
+        use ChatBotCommand::*;
+        match event {
+            EventContent::Command(command) => self.handle_command(command),
             EventContent::Join(user) => {
-                println!("{:?}", &user.0);
-                self.chatters.insert(user.0);
+                println!("{:?} joined", &user);
+                self.chatters.insert(user);
+                None
             }
             EventContent::Part(user) => {
-                self.chatters.remove(&user.0);
+                println!("{:?} parted", &user);
+                self.chatters.remove(&user);
+                None
             }
-            EventContent::TextMessage(tm) => println!("{}: {}", &tm.user_name, &tm.text),
-        };
-    }
-
-    pub async fn run(&mut self) -> Result<(), ConnectorError> {
-        self.connector.initialize().await?;
-        self.connector.send_message("Hello, world!");
-        self.connector.send_message("/followers")?;
-        loop {
-            let message = self.connector.recv_event();
-            if let Ok(event) = message {
-                self.handle_event(event);
-            };
+            EventContent::TextMessage(tm) => {
+                // this is IO and should perhaps be returned as a command
+                // we can choose to do automated moderation here
+                Some(LogTextMessage(format!("{}: {}", &tm.user_name, &tm.text)))
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod testing {
+    use crate::connect::TextMessage;
+
+    use super::*;
+
+    // It's now easy to test without connecting
+    #[test]
+    fn test_join() {
+        let mut bot = ChatBot::new();
+        let result = bot.handle_event(EventContent::Join(String::from("Carkhy")));
+        assert!(matches!(result, None));
+        assert_eq!(bot.chatters.len(), 1);
+        assert_eq!(bot.chatters.get("Carkhy").unwrap(), "Carkhy");
+    }
+    #[test]
+    fn test_part() {
+        let mut bot = ChatBot::new();
+        bot.handle_event(EventContent::Join(String::from("Carkhy")));
+        let result = bot.handle_event(EventContent::Part(String::from("Carkhy")));
+        assert!(matches!(result, None));
+        assert_eq!(bot.chatters.len(), 0);
+        assert!(matches!(bot.chatters.get("Carkhy"), None));
+    }
+    #[test]
+    fn test_text_message() {
+        let mut bot = ChatBot::new();
+        let result = bot.handle_event(EventContent::TextMessage(TextMessage {
+            text: "Hello".to_string(),
+            user_name: "Carkhy".to_string(),
+        }));
+        assert!(
+            matches!(result, Some(ChatBotCommand::LogTextMessage(message)) if message == "Carkhy: Hello")
+        );
+    }
+    #[test]
+    fn invalid_slapping() {
+        let mut bot = ChatBot::new();
+        let result = bot.handle_event(
+            EventContent::Command(
+                Command{
+                    user_name: "CaptainCallback".to_string(),
+                    commmand_type: CommandType::Slap,
+                    options: vec!["Carkhy".to_string()],
+                }));
+        assert!(matches!(result, None));
+    }
+    #[test]
+    fn abstraction_detected() {
+        let mut bot = ChatBot::new();
+        bot.handle_event(EventContent::Join(String::from("CaptainCallback")));
+        let result = bot.handle_event(
+            EventContent::Command(
+                Command{
+                    user_name: "Carkhy".to_string(),
+                    commmand_type: CommandType::Slap,
+                    options: vec!["CaptainCallback".to_string()],
+                }));
+        println!("{:#?}", result);
+        println!("{}", format!("{} slaps {} around a bit with a large trout", "Carkhy", "CaptainCallback"));
+        assert!(matches!(result, Some(ChatBotCommand::SendMessage(message))
+                         if message == format!("{} slaps {} around a bit with a large trout", "Carkhy", "CaptainCallback")));
     }
 }

--- a/chatbot/src/connect/mod.rs
+++ b/chatbot/src/connect/mod.rs
@@ -70,29 +70,11 @@ impl TextMessage {
 }
 
 #[derive(Debug)]
-pub struct Part(pub String);
-
-impl Part {
-    fn new(user_name: &str) -> Self {
-        Self(user_name.to_owned())
-    }
-}
-
-#[derive(Debug)]
-pub struct Join(pub String);
-
-impl Join {
-    fn new(user_name: &str) -> Self {
-        Self(user_name.to_owned())
-    }
-}
-
-#[derive(Debug)]
 pub enum EventContent {
     TextMessage(TextMessage),
     Command(Command),
-    Part(Part),
-    Join(Join),
+    Part(String),
+    Join(String),
 }
 
 // Example message: :carkhy!carkhy@carkhy.tmi.twitch.tv PRIVMSG #captaincallback :backseating backseating
@@ -138,9 +120,9 @@ impl EventContent {
                                 state = Channel;
                             }
                             // (...) JOIN #<channel>
-                            "JOIN" => return Some(EventContent::Join(Join::new(user_name))),
+                            "JOIN" => return Some(EventContent::Join(user_name.to_string())),
                             // (...) PART #<channel>
-                            "PART" => return Some(EventContent::Part(Part::new(user_name))),
+                            "PART" => return Some(EventContent::Part(user_name.to_string())),
                             // PING :tmi.twitch.tv
                             _ => return None,
                         };

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -1,5 +1,8 @@
 use chat_bot::ChatBot;
+use connect::TwitchChatConnector;
 use std::error::Error;
+use dotenv::dotenv;
+use std::env;
 
 extern crate websocket;
 
@@ -8,7 +11,34 @@ mod connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let _ = dotenv(); // "someone" isn't using this. We'll not say who that is
+    
+    let channel_name = env::var("TWITCH_CHANNEL")
+        .unwrap_or_else(|_| "captaincallback".to_string());
+    
+    use chat_bot::ChatBotCommand::*;
+    
+    let mut connector = TwitchChatConnector::new(&channel_name);
+    connector.initialize().await?;
+    connector.send_message("Hello, world!")?;
+    //self.connector.send_message("/followers")?; // not sure why we need this
+
     let mut chat_bot = ChatBot::new();
-    chat_bot.run().await?;
-    Ok(())
+    
+    loop {
+        let messages = connector.recv_events()?;
+        for message in messages {
+        // NOTE: we'll need to consider timed bot events, but not right now
+            if let Some(bot_command) = chat_bot.handle_event(message) {
+                match bot_command {
+                    SendMessage(message) => {
+                        println!("Sending this message : {}", &message);
+                        connector.send_message(&message)?;
+                    },
+                    LogTextMessage(message) => println!("{}", message),
+                }
+            }
+            
+        }
+    }
 }


### PR DESCRIPTION
- Added .env support because my bot doesn't work in your channel
- Removed info and help messages from chatbot struct
- Moved IO from chatbot to main fn
- Added chatbot tests
- Part and Join now directly include the user_name String
- recv_event renamed to recv_events, and returns a Vec<EventContent>
- This PR is way too big and all over the place, i'm ashamed
