### PR TITLE
Implemented repeating messages

### DIFF
--- a/chatbot/Cargo.toml
+++ b/chatbot/Cargo.toml
@@ -13,3 +13,5 @@ serde_json = "1.0.68"
 tiny_http = { version = "0.9.0", features = ["ssl"] }
 thiserror = "1.0"
 dotenv = "0.15"
+uuid = { version = "0.8", features = ["v4"] }
+thread_timer = "0.3"

--- a/chatbot/src/connect/connector/mod.rs
+++ b/chatbot/src/connect/connector/mod.rs
@@ -1,3 +1,3 @@
-mod twitch_chat;
+pub(crate) mod twitch_chat;
 
 pub use twitch_chat::TwitchChatConnector;

--- a/chatbot/src/connect/connector/twitch_chat/mod.rs
+++ b/chatbot/src/connect/connector/twitch_chat/mod.rs
@@ -1,6 +1,6 @@
 mod auth;
 mod connector;
 mod receive;
-mod send;
+pub(crate) mod send;
 
 pub use connector::TwitchChatConnector;

--- a/chatbot/src/connect/connector/twitch_chat/send/generator.rs
+++ b/chatbot/src/connect/connector/twitch_chat/send/generator.rs
@@ -4,12 +4,12 @@ pub fn get_login_tasks<'a>(
     password: &'a str,
     user_name: &'a str,
     channel: &'a str,
-) -> Vec<SendTask<'a>> {
+) -> Vec<SendTask> {
     return vec![
-        SendTask::ProvideLoginPassword(password),
-        SendTask::ProvideLoginUserName(user_name),
-        SendTask::JoinChannel(channel),
-        SendTask::RequestCapabilities("membership"),
-        SendTask::RequestCapabilities("tags"),
+        SendTask::ProvideLoginPassword(password.to_string()),
+        SendTask::ProvideLoginUserName(user_name.to_string()),
+        SendTask::JoinChannel(channel.to_string()),
+        SendTask::RequestCapabilities("membership".to_string()),
+        SendTask::RequestCapabilities("tags".to_string()),
     ];
 }

--- a/chatbot/src/connect/connector/twitch_chat/send/handler.rs
+++ b/chatbot/src/connect/connector/twitch_chat/send/handler.rs
@@ -3,8 +3,8 @@ use crate::connect::error::ConnectorError;
 use std::net::TcpStream;
 use websocket::{sync::Writer, Message};
 
-pub fn handle_sending_task<'a>(
-    sender: &'a mut Writer<TcpStream>,
+pub fn handle_sending_task(
+    sender: &mut Writer<TcpStream>,
     task: SendTask,
 ) -> Result<(), ConnectorError> {
     let message = Message::text(task.to_string());
@@ -13,12 +13,12 @@ pub fn handle_sending_task<'a>(
     })
 }
 
-pub fn handle_multiple_sending_tasks<'a>(
-    sender: &'a mut Writer<TcpStream>,
+pub fn handle_multiple_sending_tasks(
+    sender: &mut Writer<TcpStream>,
     tasks: Vec<SendTask>,
 ) -> Result<(), ConnectorError> {
     for task in tasks {
         handle_sending_task(sender, task)?;
     }
-    return Ok(());
+    Ok(())
 }

--- a/chatbot/src/connect/connector/twitch_chat/send/task.rs
+++ b/chatbot/src/connect/connector/twitch_chat/send/task.rs
@@ -1,13 +1,13 @@
-pub enum SendTask<'a> {
-    PrivateMessage(&'a str, &'a str),
-    ProvideLoginPassword(&'a str),
-    ProvideLoginUserName(&'a str),
-    JoinChannel(&'a str),
-    RequestCapabilities(&'a str),
+pub enum SendTask {
+    PrivateMessage(String, String),
+    ProvideLoginPassword(String),
+    ProvideLoginUserName(String),
+    JoinChannel(String),
+    RequestCapabilities(String),
     Pong,
 }
 
-impl<'a> ToString for SendTask<'a> {
+impl ToString for SendTask {
     fn to_string(&self) -> String {
         match self {
             Self::PrivateMessage(channel, message) => format!("PRIVMSG #{} :{}", channel, message),
@@ -28,31 +28,31 @@ mod tests {
 
     #[test]
     fn prints_private_messages_correctly() {
-        let task = SendTask::PrivateMessage("channelname", "Message");
+        let task = SendTask::PrivateMessage("channelname".to_string(), "Message".to_string());
         assert_eq!(task.to_string(), "PRIVMSG #channelname :Message");
     }
 
     #[test]
     fn prints_login_password_messages_correctly() {
-        let task = SendTask::ProvideLoginPassword("admin123");
+        let task = SendTask::ProvideLoginPassword("admin123".to_string());
         assert_eq!(task.to_string(), "PASS oauth:admin123");
     }
 
     #[test]
     fn prints_login_username_messages_correctly() {
-        let task = SendTask::ProvideLoginUserName("user123");
+        let task = SendTask::ProvideLoginUserName("user123".to_string());
         assert_eq!(task.to_string(), "NICK user123");
     }
 
     #[test]
     fn prints_join_channel_messages_correctly() {
-        let task = SendTask::JoinChannel("channel123");
+        let task = SendTask::JoinChannel("channel123".to_string());
         assert_eq!(task.to_string(), "JOIN #channel123");
     }
 
     #[test]
     fn prints_request_capabilities_messages_correctly() {
-        let task = SendTask::RequestCapabilities("capability123");
+        let task = SendTask::RequestCapabilities("capability123".to_string());
         assert_eq!(task.to_string(), "CAP REQ :twitch.tv/capability123");
     }
 

--- a/chatbot/src/connect/error.rs
+++ b/chatbot/src/connect/error.rs
@@ -1,4 +1,8 @@
+use std::sync::mpsc::SendError;
+
 use thiserror::Error;
+
+use super::connector::twitch_chat::send::SendTask;
 
 #[derive(Error, Debug)]
 pub enum ConnectorError {
@@ -6,4 +10,6 @@ pub enum ConnectorError {
     MessageReceiveFailed(String),
     #[error("Sending message failed: {0:?}")]
     MessageSendFailed(String),
+    #[error("Send error {0:?}")]
+    SendFailed(#[from]SendError<SendTask>),
 }

--- a/chatbot/src/connect/types/command.rs
+++ b/chatbot/src/connect/types/command.rs
@@ -9,6 +9,8 @@ pub enum CommandType {
     Slap,
     Discord,
     Dynamic(String),
+    NewRepeating,
+    RemoveRepeating,
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/chatbot/src/connect/types/event.rs
+++ b/chatbot/src/connect/types/event.rs
@@ -1,3 +1,5 @@
+use uuid::Uuid;
+
 use super::{text_message::TextMessage, Command};
 
 #[derive(Debug, PartialEq)]
@@ -6,4 +8,8 @@ pub enum ChatBotEvent {
     Command(Command),
     Part(String),
     Join(String),
+    // timer sends a message to the bot, String is the name of the message.
+    // uuid is the message id, used to deduplicate
+    // messages when a command is redefined
+    TimedMessage(String, Uuid),
 }

--- a/chatbot/src/core/command.rs
+++ b/chatbot/src/core/command.rs
@@ -1,5 +1,13 @@
+use std::time::Duration;
+
+use crate::connect::ChatBotEvent;
+
 #[derive(Debug)]
 pub enum ChatBotCommand {
     SendMessage(String),
     LogTextMessage(String),
+    // bot registers to be called back with the specified event
+    TimedCallback{duration: Duration, event: ChatBotEvent},
+    // bot sends more than one command
+    MultipleCommands(Vec<ChatBotCommand>),
 }

--- a/chatbot/src/main.rs
+++ b/chatbot/src/main.rs
@@ -1,37 +1,64 @@
-use crate::core::{ChatBot, ChatBotCommand::*};
+use crate::{
+    connect::ChatBotEvent,
+    core::{
+        ChatBot,
+        ChatBotCommand::{self, *},
+    },
+};
 use app_config::AppConfig;
 use connect::TwitchChatConnector;
-use std::error::Error;
-
-extern crate websocket;
+use std::sync::mpsc;
+use std::{error::Error, sync::mpsc::Sender};
+use thread_timer::ThreadTimer;
 
 pub mod app_config;
 mod connect;
 mod core;
 
+fn process_command(
+    command: ChatBotCommand,
+    connector: &TwitchChatConnector,
+    bot_event_sender: Sender<ChatBotEvent>,
+) -> Result<(), Box<dyn Error>> {
+    match command {
+        SendMessage(message) => {
+            println!("Sending this message : {}", &message);
+            connector.send_message(&message)?;
+        }
+        LogTextMessage(message) => println!("{}", message),
+        TimedCallback { duration, event } => {
+            // This timer spawns a thread per invokation, that's bad
+            // More serious timers were not a good fit (afaik)
+            // It would be a nice exercise to implement such timer with
+            // one or 2 threads for all timers
+            let timer = ThreadTimer::new();
+            let _ = timer.start(duration, move || {
+                let _ = bot_event_sender.send(event);
+            });
+        }
+        MultipleCommands(new_commands) => {
+            for command in new_commands {
+                process_command(command, connector, bot_event_sender.clone())?;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let app_config = AppConfig::new()?;
 
-    let mut connector = TwitchChatConnector::new(&app_config).await;
+    let (tx, rx) = mpsc::channel();
+
+    let connector = TwitchChatConnector::new(&app_config, tx.clone()).await;
     connector.send_message("Hello, world!")?;
-    //self.connector.send_message("/followers")?; // not sure why we need this
 
     let mut chat_bot = ChatBot::new();
-
-    loop {
-        let messages = connector.recv_events()?;
-        for message in messages {
-            // NOTE: we'll need to consider timed bot events, but not right now
-            if let Some(bot_command) = chat_bot.handle_event(message) {
-                match bot_command {
-                    SendMessage(message) => {
-                        println!("Sending this message : {}", &message);
-                        connector.send_message(&message)?;
-                    }
-                    LogTextMessage(message) => println!("{}", message),
-                }
-            }
+    while let Ok(message) = rx.recv() {
+        if let Some(bot_command) = chat_bot.handle_event(message) {
+            process_command(bot_command, &connector, tx.clone())?;
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
Yet another huge PR. There is much to say about it.
I implemented repeating messages.
The goal was to use the communication pattern we already have to the ChatBot struct. That is incoming ChatBotEvents and outgoing ChatBotCommands.
Up to this point, we were blocking on receiving messages from the connector. This was preventing any message coming from another source to arrive to our ChatBot. 
So I went ahead and created a channel that is responsible for receiving and dispatching the ChatBotEvents to our bot.
We're now blocking on that channel in main.
In order to not block on receiving messages from the connector, I put it in a thread, passing a sender to the channel I described earlier to that thread.
Now I needed a way to send messages to the websocket from that thread, so I created another thread for writing, and gave a channel that allows for writing there to our reader thread. This allows for responding to PING messages, and whatever uses we might require in the future.

So now we have Connector -> channel -> main -> bot.
It was then easy to add a timer. so that we now have:
```
Connector \
           > channel -> main -> bot
    Timer /
```
Some destruction of your work was necessary to reach that goal. 
I made the Strings in Task owned, removing the lifetime annotations. While it is true that the traffic of the bot is capped by Twitch and your optimization is not very important, the real reason i did this is because i couldn't make it work across threads. It must be possible but I ain't spending more time on that particular problem. If string duplication is really an  issue, maybe some kind of smart pointer (Arc) might do the trick, but i can see this being infectious.

BTW: I don't quite understand the need for this Task thing, that's an indirection that, in my opinion, doesn't bring much to the table.

So we end up with these new commands : 
!newrepeating hello 60 Hello there !
!removerepeating hello

When newrepeating is invoked, two commands are sent back to main. One is a message (which you need to decide on), the other is registering for the bot to be called back with a TimedMessageEvent. 
This starts the timer, which will call our bot back with the specified timeout.
Once the bot receives the TimedMessageEvent, it returns two commands, one to output the message, and another to register to be called back again with the same message.

I eschewed testing in the bot file, because it all worked on the second cargo run attempt ! I had a single off-by-one error, looks like rust is pretty good =)
